### PR TITLE
이세은: 섹션06 미션 제출

### DIFF
--- a/seeun/src/mission2/Josephus.java
+++ b/seeun/src/mission2/Josephus.java
@@ -1,0 +1,61 @@
+package mission2;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+public class Josephus {
+
+    public static void main(String[] args) {
+
+        long start = System.nanoTime();
+        josephusWithArrayList(100000, 3);
+        long end = System.nanoTime();
+        System.out.println("ArrayList를 활용한 실행시간: " + (end - start));
+
+        start = System.nanoTime();
+        josephusWithLinkedList(100000, 3);
+        end = System.nanoTime();
+        System.out.println("LinkedList를 활용한 실행시간: " + (end - start));
+
+    }
+
+    public static void josephusWithArrayList(int n, int k) {
+
+        ArrayList<Integer> list = new ArrayList<>();
+
+        for (int i = 1; i <= n; i++) {
+            list.add(i);
+        }
+
+        int index = 0;
+        while (!list.isEmpty()) {
+            index = (index + (k - 1)) % list.size();
+
+            if (list.size() == 1) {
+                System.out.println(list.remove(index));
+                return;
+            }
+            list.remove(index);
+        }
+    }
+
+    public static void josephusWithLinkedList(int n, int k) {
+        LinkedList<Integer> list = new LinkedList<>();
+
+        for (int i = 1; i <= n; i++) {
+            list.add(i);
+        }
+
+        int index = 0;
+        while (!list.isEmpty()) {
+            index = (index + (k - 1)) % list.size();
+
+            if (list.size() == 1) {
+                System.out.println(list.remove(index));
+                return;
+            }
+            list.remove(index);
+        }
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#4 
## 📝미션 내용

원형에 앉아있는 n명의 사람들 중 k번째에 앉아있는 사람을 계속해서 제외시키고 남은 한사람을 출력하는 문제였습니다.
로직 자체는 어렵지 않았지만 그 안에서 많은 자료구조의 조작이 들어가기 때문에 여러 효율성에 대해서 생각해보는 계기가 되었습니다.

우선 ArrayList는 연속된 메모리에 요소를 저장해 메모리 측면에서 효율적입니다. 또한 특정 요소를 인덱스로 O(1)로 접근이 가능합니다. 
하지만 특정 요소를 제거한다면 제거 후 다른 요소들을 밀어주기 위해 평균 O(n)의 시프트 연산이 필요합니다.
이 문제에서는 n-1번의 제거를 하므로 (n-1) * n = O(n^2)의 시간 복잡도가 듭니다.

LinkedList는 꼭 연속된 메모리에 저장하는 것이 아닌 각 요소의 메모리를 포인터로 연결합니다. 요소를 제거하는 데 O(1)로 효율적입니다.
하지만 특정 인덱스에 접근하기 위해서 O(n)이 필요하고 (n-1) * n = O(n^2)의 시간 복잡도가 듭니다.

### 학습내용 요약

아직 강의를 전부 듣지 못했습니다. 추후 반영하겠습니다!

## 💬리뷰 요구사항

피드백 환영합니다.